### PR TITLE
feat: add isrc support [DB migration]

### DIFF
--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/MediaFileEntry.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/MediaFileEntry.java
@@ -35,6 +35,7 @@ public class MediaFileEntry {
     private final String remoteStreamUrl;
     private final String coverArtUrl;
     private final String remoteCoverArtUrl;
+    private final String isrc;
 
     public MediaFileEntry(
             int id,
@@ -64,7 +65,9 @@ public class MediaFileEntry {
             String streamUrl,
             String remoteStreamUrl,
             String coverArtUrl,
-            String remoteCoverArtUrl) {
+            String remoteCoverArtUrl,
+            String isrc
+    ) {
         this.id = id;
         this.trackNumber = trackNumber;
         this.discNumber = discNumber;
@@ -93,6 +96,7 @@ public class MediaFileEntry {
         this.remoteStreamUrl = remoteStreamUrl;
         this.coverArtUrl = coverArtUrl;
         this.remoteCoverArtUrl = remoteCoverArtUrl;
+        this.isrc = isrc;
     }
 
     public int getId() {
@@ -223,6 +227,10 @@ public class MediaFileEntry {
         return lastScanned;
     }
 
+    public String getISRC() {
+        return isrc;
+    }
+
     public static MediaFileEntry fromMediaFile(MediaFile file, Locale locale, boolean starred, boolean folderAccess, String streamUrl, String remoteStreamUrl, String remoteCoverArtUrl) {
         return new MediaFileEntry(file.getId(), file.getTrackNumber(), file.getDiscNumber(), file.getName(),
                 file.getArtist(), file.getAlbumArtist(), file.getAlbumName(), file.getGenre(), file.getYear(), formatBitRate(file),
@@ -231,7 +239,7 @@ public class MediaFileEntry {
                 StringUtil.formatBytes(file.getFileSize(), locale == null ? Locale.ENGLISH : locale),
                 file.getPlayCount(), file.getLastPlayed(), file.getCreated(), file.getChanged(), file.getLastScanned(),
                 starred, file.isPresent() && folderAccess, "main.view?id=" + file.getId(), streamUrl, remoteStreamUrl,
-                "coverArt.view?id=" + file.getId(), remoteCoverArtUrl);
+                "coverArt.view?id=" + file.getId(), remoteCoverArtUrl, file.getISRC());
     }
 
     private static String formatBitRate(MediaFile mediaFile) {

--- a/airsonic-main/src/main/java/org/airsonic/player/ajax/MediaFileWSController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/ajax/MediaFileWSController.java
@@ -240,7 +240,7 @@ public class MediaFileWSController {
                     mfe.getDimensions(), mfe.getDuration(), mfe.getFormat(), mfe.getContentType(), mfe.getEntryType(),
                     mfe.getFileSize(), mfe.getPlayCount(), mfe.getLastPlayed(), mfe.getCreated(), mfe.getChanged(),
                     mfe.getLastScanned(), mfe.getStarred(), mfe.getPresent(), mfe.getAlbumUrl(), mfe.getStreamUrl(),
-                    mfe.getRemoteStreamUrl(), mfe.getCoverArtUrl(), mfe.getRemoteCoverArtUrl());
+                    mfe.getRemoteStreamUrl(), mfe.getCoverArtUrl(), mfe.getRemoteCoverArtUrl(), mfe.getISRC());
         }
 
         public List<MediaFileEntry> getFiles() {

--- a/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -505,7 +505,8 @@ public class SubsonicRESTController {
         jaxbWriter.writeResponse(request, response, res);
     }
 
-    private <T extends ArtistID3> T createJaxbArtist(T jaxbArtist, org.airsonic.player.domain.Artist artist, String username) {
+    private <T extends ArtistID3> T createJaxbArtist(T jaxbArtist, org.airsonic.player.domain.Artist artist, String username)
+    {
         jaxbArtist.setId(String.valueOf(artist.getId()));
         jaxbArtist.setName(artist.getName());
         jaxbArtist.setStarred(jaxbWriter.convertDate(artistService.getStarredDate(artist.getId(), username)));
@@ -1072,6 +1073,8 @@ public class SubsonicRESTController {
         writeEmptyResponse(request, response);
     }
 
+
+
     @RequestMapping({"/deletePlaylist", "/deletePlaylist.view"})
     public void deletePlaylist(HttpServletRequest request, HttpServletResponse response) throws Exception {
         request = wrapRequest(request, true);
@@ -1291,6 +1294,7 @@ public class SubsonicRESTController {
             child.setContentType(StringUtil.getMimeType(suffix));
             child.setIsVideo(mediaFile.isVideo());
             child.setPath(mediaFile.getPath());
+            child.setIsrc(mediaFile.getISRC());
 
             Album album = albumService.getAlbumByMediaFile(mediaFile);
 

--- a/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -152,6 +152,9 @@ public class MediaFile {
     @Column(name = "mb_recording_id", nullable = true)
     private String musicBrainzRecordingId;
 
+    @Column(name = "isrc", nullable = true)
+    private String isrc;
+
     @Transient
     private Double averageRating = 0.0;
 
@@ -475,6 +478,14 @@ public class MediaFile {
 
     public void setMusicBrainzRecordingId(String musicBrainzRecordingId) {
         this.musicBrainzRecordingId = musicBrainzRecordingId;
+    }
+
+    public String getISRC() {
+        return isrc;
+    }
+
+    public void setISRC(String isrc) {
+        this.isrc = isrc;
     }
 
     /**

--- a/airsonic-main/src/main/java/org/airsonic/player/repository/MediaFileRepository.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/repository/MediaFileRepository.java
@@ -87,6 +87,9 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Integer> {
     public List<MediaFile> findByAlbumArtistAndAlbumNameAndMediaTypeInAndPresentTrue(String albumArtist, String albumName,
             List<MediaType> mediaTypes, Sort sort);
 
+    public Optional<MediaFile> findByIsrc(String isrc);
+
+    public List<MediaFile> findByIsrcIn(Iterable<String> isrcs);
 
     public Optional<MediaFile> findByPathAndFolderAndStartPosition(String path, MusicFolder folder, Double startPosition);
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -241,6 +241,14 @@ public class MediaFileService {
         return mediaFileRepository.findByPath(relativePath.toString());
     }
 
+    public Optional<MediaFile> getMediaFileByISRC(String isrc) {
+        return mediaFileRepository.findByIsrc(isrc);
+    }
+
+    public List<MediaFile> getMediaFilesByISRC(Iterable<String> isrc) {
+        return mediaFileRepository.findByIsrcIn(isrc);
+    }
+
     public MediaFile getParentOf(MediaFile mediaFile) {
         return getParentOf(mediaFile, settingsService.isFastCacheEnabled());
     }
@@ -1025,6 +1033,7 @@ public class MediaFileService {
                 mediaFile.setWidth(metaData.getWidth());
                 mediaFile.setMusicBrainzReleaseId(metaData.getMusicBrainzReleaseId());
                 mediaFile.setMusicBrainzRecordingId(metaData.getMusicBrainzRecordingId());
+                mediaFile.setISRC(metaData.getISRC());
             }
             String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(mediaFile.getPath())));
             mediaFile.setFormat(format);
@@ -1262,6 +1271,7 @@ public class MediaFileService {
                     track.setFormat(base.getFormat());
                     track.setStartPosition(currentStart);
                     track.setDuration(duration);
+                    track.setISRC(base.getISRC());
                     // estimate file size based on duration and whole file size
                     long estimatedSize = (long) (duration / wholeFileLength * wholeFileSize);
                     // if estimated size is within of whole file size, use it. Otherwise use whole file size divided by number of tracks

--- a/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/PlayQueueService.java
@@ -613,7 +613,8 @@ public class PlayQueueService {
                     streamUrl, // Stream URL
                     streamUrl, // Remote stream URL
                     null, // Cover art URL
-                    null // Remote cover art URL
+                    null, // Remote cover art URL
+                    ""  // ISRC XXX: Not implemented
             ));
         }
 

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -94,6 +94,7 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setTrackNumber(parseIntegerPattern(getTagField(tag, FieldKey.TRACK), TRACK_NUMBER_PATTERN));
                 metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
                 metaData.setMusicBrainzRecordingId(getTagField(tag, FieldKey.MUSICBRAINZ_TRACK_ID));
+                metaData.setISRC(getTagField(tag, FieldKey.ISRC));
 
                 metaData.setArtist(getTagField(tag, FieldKey.ARTIST));
                 metaData.setAlbumArtist(getTagField(tag, FieldKey.ALBUM_ARTIST));

--- a/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/airsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -46,6 +46,7 @@ public class MetaData {
     private Integer height;
     private String musicBrainzReleaseId;
     private String musicBrainzRecordingId;
+    private String isrc;
     private final List<Track> tracks = new ArrayList<>();
     private final List<Chapter> chapters = new ArrayList<>();
 
@@ -167,6 +168,14 @@ public class MetaData {
 
     public void setMusicBrainzRecordingId(String musicBrainzRecordingId) {
         this.musicBrainzRecordingId = musicBrainzRecordingId;
+    }
+
+    public String getISRC() {
+        return isrc;
+    }
+
+    public void setISRC(String isrc) {
+        this.isrc = isrc;
     }
 
     public void addTrack(Track track) {

--- a/airsonic-main/src/main/resources/liquibase/11.1/add-isrc.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.1/add-isrc.xml
@@ -1,0 +1,18 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-isrc" author="lunarix">
+        <validCheckSum>ANY</validCheckSum>
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="isrc" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="isrc" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/airsonic-main/src/main/resources/liquibase/11.1/changelog.xml
+++ b/airsonic-main/src/main/resources/liquibase/11.1/changelog.xml
@@ -2,6 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="add-isrc.xml" relativeToChangelogFile="true"/>
     <include file="add-user-credentials-id.xml" relativeToChangelogFile="true"/>
     <include file="add-deleted-column-music-folder.xml" relativeToChangelogFile="true"/>
     <include file="remove-genre-name-duplication.xml" relativeToChangelogFile="true"/>

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -255,6 +255,7 @@
         <xs:attribute name="bookmarkPosition" type="xs:long" use="optional"/>  <!-- In millis. Added in 1.10.1 -->
         <xs:attribute name="originalWidth" type="xs:int" use="optional"/>  <!-- Added in 1.13.0 -->
         <xs:attribute name="originalHeight" type="xs:int" use="optional"/>  <!-- Added in 1.13.0 -->
+        <xs:attribute name="isrc" type="xs:string" use="optional"/>  <!-- Added in 1.15.0 -->
     </xs:complexType>
 
     <xs:simpleType name="MediaType">


### PR DESCRIPTION
- `isrc` field to media_file database.
- `isrc` as an xml field on the rest api for any `Child`
- `isrc` is parsed from metadata present in the audio
- !! PlayQueueService get passed `""` for isrc