### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/airsonic-main/src/main/resources/static/script/wz_tooltip.js
+++ b/airsonic-main/src/main/resources/static/script/wz_tooltip.js
@@ -114,7 +114,16 @@ function Tip()
 }
 function TagToTip()
 {
-	var t2t = tt_GetElt(arguments[0]);
+	var id = arguments[0];
+	// Only allow standard element ID characters to prevent DOM text from being
+	// reinterpreted as HTML through later innerHTML rendering.
+	if(!/^[A-Za-z][\w\-:\.]*$/.test(id))
+	{
+		if(tt_Debug)
+			tt_Err("Invalid ID\n'" + id + "'\npassed to TagToTip().", true);
+		return;
+	}
+	var t2t = tt_GetElt(id);
 	if(t2t)
 		tt_Tip(arguments, t2t);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Skarlett/airsonic-advanced-feat-isrc/security/code-scanning/1](https://github.com/Skarlett/airsonic-advanced-feat-isrc/security/code-scanning/1)

The safest fix without changing intended behavior is to **validate/sanitize the ID argument passed to `TagToTip` before using it**, so only legitimate element IDs are accepted and unexpected characters are rejected. This prevents attacker-controlled strings from flowing into tooltip HTML assembly paths.

Best single fix in shown code:
- **File:** `airsonic-main/src/main/resources/static/script/wz_tooltip.js`
- **Region:** `TagToTip()` around lines 115–120.
- Add a strict ID whitelist check (letters, digits, `_`, `-`, `:`, `.`) before calling `tt_GetElt`.
- If invalid, fail closed (`return;`) optionally with existing `tt_Err` when debug is enabled.
- Keep existing behavior for valid IDs.

No functional change for normal IDs like `placeholder-...`, but blocks malformed/hostile values from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
